### PR TITLE
fix: regex inside function get_route_path to remove root_path

### DIFF
--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -95,5 +95,5 @@ def collapse_excgroups() -> typing.Generator[None, None, None]:
 
 def get_route_path(scope: Scope) -> str:
     root_path = scope.get("root_path", "")
-    route_path = re.sub(r"^" + root_path, "", scope["path"])
+    route_path = re.sub(r"^" + root_path + r"(?=/|$)", "", scope["path"])
     return route_path

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -1,7 +1,10 @@
 import functools
 from typing import Any
 
-from starlette._utils import is_async_callable
+import pytest
+
+from starlette._utils import get_route_path, is_async_callable
+from starlette.types import Scope
 
 
 def test_async_func() -> None:
@@ -89,3 +92,15 @@ def test_async_nested_partial() -> None:
     partial = functools.partial(async_func, b=2)
     nested_partial = functools.partial(partial, a=1)
     assert is_async_callable(nested_partial)
+
+
+@pytest.mark.parametrize(
+    "scope, expected_result",
+    [
+        ({"path": "/foo-123/bar", "root_path": "/foo"}, "/foo-123/bar"),
+        ({"path": "/foo/bar", "root_path": "/foo"}, "/bar"),
+        ({"path": "/foo", "root_path": "/foo"}, ""),
+    ],
+)
+def test_get_route_path(scope: Scope, expected_result: str) -> None:
+    assert get_route_path(scope) == expected_result

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1292,6 +1292,12 @@ echo_paths_routes = [
         name="path",
         methods=["GET"],
     ),
+    Route(
+        "/root-queue/path",
+        functools.partial(echo_paths, name="queue_path"),
+        name="queue_path",
+        methods=["POST"],
+    ),
     Mount("/asgipath", app=functools.partial(pure_asgi_echo_paths, name="asgipath")),
     Mount(
         "/sub",
@@ -1338,4 +1344,12 @@ def test_paths_with_root_path(test_client_factory: TestClientFactory) -> None:
         "name": "subpath",
         "path": "/root/sub/path",
         "root_path": "/root/sub",
+    }
+
+    response = client.post("/root/root-queue/path")
+    assert response.status_code == 200
+    assert response.json() == {
+        "name": "queue_path",
+        "path": "/root/root-queue/path",
+        "root_path": "/root",
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This pull request adjusts the regular expression used in the get_route_path function to ensure correct behavior when scope["path"] contains the root_path.

Changes:

Updated the regex pattern to include a positive lookahead assertion to match either a / character or the end of the string ((?=/|$)), ensuring accurate substitution.

Cases:
scope = {"path": "/foo-123/bar", "root_path": "foo"}
print(get_route_path(scope))  # Output: '/foo-123/bar'

scope = {"path": "/foo/bar", "root_path": "foo"}
print(get_route_path(scope))  # Output: '/bar'

scope = {"path": "/foo", "root_path": "foo"}
print(get_route_path(scope))  # Output: ''

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
